### PR TITLE
feat: add automatic check modifiers

### DIFF
--- a/EveryThingDnd/RollsView.swift
+++ b/EveryThingDnd/RollsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct RollsView: View {
-    var character: Character?
+    var character: Character
     @State private var check: CheckType = .ability(.str)
     @State private var damageExpression: String = "1d6"
     @State private var critical: Bool = false
@@ -32,7 +32,6 @@ struct RollsView: View {
     }
 
     private func rollCheck() {
-        guard let character else { resultText = "Select a character first"; return }
         var rng = SystemRandomNumberGenerator()
         let result = DiceEngine.check(type: check, character: character, rng: &rng)
         var parts: [String] = ["d20: \(result.d20)", "ability: \(result.abilityMod)"]

--- a/EveryThingDnd/SettingsView.swift
+++ b/EveryThingDnd/SettingsView.swift
@@ -1,16 +1,8 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage("layoutStyle") private var layoutStyle: String = "2014"
     var body: some View {
         Form {
-            Section("Character Sheet") {
-                Picker("Layout", selection: $layoutStyle) {
-                    Text("2014").tag("2014")
-                    Text("2024").tag("2024")
-                }
-                .pickerStyle(.segmented)
-            }
             Section {
                 NavigationLink("About") { AboutView() }
             }

--- a/EveryThingDndTests/EveryThingDndTests.swift
+++ b/EveryThingDndTests/EveryThingDndTests.swift
@@ -17,10 +17,22 @@ struct DiceEngineTests {
         #expect(result.rolls == [3,4])
     }
 
-    @Test func abilityCheck() async throws {
+    @Test func checkAppliesProficiency() async throws {
         var rng = FixedRNG(numbers: [10])
         let character = Character(str: 16, level: 5)
-        let result = DiceEngine.abilityCheck(for: .str, character: character, proficiency: .proficient, advantage: .normal, rng: &rng)
+        character.setProficiency(.proficient, for: .athletics)
+        let result = DiceEngine.check(type: .skill(.athletics), character: character, rng: &rng)
         #expect(result.total == 10 + 3 + character.proficiencyBonus)
+        #expect(result.proficient)
+        #expect(!result.expertise)
+    }
+
+    @Test func checkAppliesExpertise() async throws {
+        var rng = FixedRNG(numbers: [5])
+        let character = Character(dex: 14, level: 5)
+        character.setProficiency(.expertise, for: .stealth)
+        let result = DiceEngine.check(type: .skill(.stealth), character: character, rng: &rng)
+        #expect(result.total == 5 + 2 + character.proficiencyBonus * 2)
+        #expect(result.expertise)
     }
 }


### PR DESCRIPTION
## Summary
- unify character sheet into single editable layout
- add check roll engine with automatic proficiency and expertise modifiers
- simplify rolls UI to choose check type and show breakdown

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68abb9e46544832c842034d8c6327a10

## Summary by Sourcery

Introduce a unified, editable character sheet layout and a new check roll engine that automatically applies proficiency and expertise. Simplify UI components, persist ability proficiencies in the data model, and update tests to cover the new roll logic.

New Features:
- Unify character sheet into a single editable layout with inline ability score fields and proficiency pickers
- Add CheckType enum and DiceEngine.check method to roll ability and skill checks with automatic proficiency and expertise modifiers
- Update RollsView to select any check type and display a detailed roll breakdown

Enhancements:
- Persist ability proficiencies via new AbilityEntry model and extend Character with get/set proficiency methods
- Simplify CharacterSheetView and remove legacy layout toggles and SettingsView layout options

Tests:
- Update tests to verify proficiency and expertise are correctly applied in check rolls